### PR TITLE
feat: add generic key-path convenience API for structured collections

### DIFF
--- a/Sources/FuzzyMatch/FuzzyMatch.docc/FuzzyMatch.md
+++ b/Sources/FuzzyMatch/FuzzyMatch.docc/FuzzyMatch.md
@@ -77,4 +77,5 @@ for candidate in candidates {
 
 - ``ScoredMatch``
 - ``MatchResult``
+- ``ItemMatchResult``
 - ``MatchKind``

--- a/Sources/FuzzyMatch/FuzzyMatcher+KeyPathConvenience.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher+KeyPathConvenience.swift
@@ -1,0 +1,176 @@
+// ===----------------------------------------------------------------------===//
+//
+// This source file is part of the FuzzyMatch open source project
+//
+// Copyright (c) 2026 Ordo One, AB. and the FuzzyMatch project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ===----------------------------------------------------------------------===//
+
+extension FuzzyMatcher {
+    /// Returns the top matches from a sequence of items, matching against a string
+    /// property extracted via key path, sorted by score descending.
+    ///
+    /// This is the generic counterpart of ``topMatches(_:against:limit:)-7q3wo``.
+    /// Instead of requiring a sequence of strings, it accepts any sequence of items
+    /// and a key path to the string property to match against.
+    ///
+    /// - Parameters:
+    ///   - candidates: The items to search.
+    ///   - keyPath: A key path to the string property to match against.
+    ///   - query: A prepared query from ``prepare(_:)``.
+    ///   - limit: Maximum number of results to return. Default is `10`.
+    /// - Returns: An array of ``ItemMatchResult`` sorted by score descending,
+    ///   containing at most `limit` elements.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// struct Instrument {
+    ///     let ticker: String
+    ///     let name: String
+    /// }
+    ///
+    /// let instruments = [
+    ///     Instrument(ticker: "AAPL", name: "Apple Inc"),
+    ///     Instrument(ticker: "MSFT", name: "Microsoft Corporation"),
+    ///     Instrument(ticker: "GOOG", name: "Alphabet Inc"),
+    /// ]
+    ///
+    /// let matcher = FuzzyMatcher()
+    /// let query = matcher.prepare("apple")
+    /// let results = matcher.topMatches(instruments, by: \.name, against: query, limit: 3)
+    /// for result in results {
+    ///     print("\(result.item.ticker): \(result.match.score)")
+    /// }
+    /// ```
+    public func topMatches<Item>(
+        _ candidates: some Sequence<Item>,
+        by keyPath: KeyPath<Item, String>,
+        against query: FuzzyQuery,
+        limit: Int = 10
+    ) -> [ItemMatchResult<Item>] {
+        var buffer = makeBuffer()
+        var results: [ItemMatchResult<Item>] = []
+        results.reserveCapacity(limit)
+
+        for candidate in candidates {
+            guard let match = score(candidate[keyPath: keyPath], against: query, buffer: &buffer) else {
+                continue
+            }
+            let result = ItemMatchResult(item: candidate, match: match)
+            if results.count < limit {
+                results.append(result)
+                if results.count == limit {
+                    results.sort { $0.match.score > $1.match.score }
+                }
+            } else if match.score > results[results.count - 1].match.score {
+                results[results.count - 1] = result
+                results.sort { $0.match.score > $1.match.score }
+            }
+        }
+
+        if results.count < limit {
+            results.sort { $0.match.score > $1.match.score }
+        }
+
+        return results
+    }
+
+    /// Returns all matching items sorted by score descending, matching against a
+    /// string property extracted via key path.
+    ///
+    /// This is the generic counterpart of ``matches(_:against:)-1fvd5``.
+    /// Instead of requiring a sequence of strings, it accepts any sequence of items
+    /// and a key path to the string property to match against.
+    ///
+    /// - Parameters:
+    ///   - candidates: The items to search.
+    ///   - keyPath: A key path to the string property to match against.
+    ///   - query: A prepared query from ``prepare(_:)``.
+    /// - Returns: An array of ``ItemMatchResult`` sorted by score descending.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// struct Instrument {
+    ///     let ticker: String
+    ///     let name: String
+    /// }
+    ///
+    /// let instruments = [
+    ///     Instrument(ticker: "AAPL", name: "Apple Inc"),
+    ///     Instrument(ticker: "MSFT", name: "Microsoft Corporation"),
+    ///     Instrument(ticker: "GOOG", name: "Alphabet Inc"),
+    /// ]
+    ///
+    /// let matcher = FuzzyMatcher()
+    /// let query = matcher.prepare("inc")
+    /// let all = matcher.matches(instruments, by: \.name, against: query)
+    /// // Returns matches for instruments whose names match "inc"
+    /// ```
+    public func matches<Item>(
+        _ candidates: some Sequence<Item>,
+        by keyPath: KeyPath<Item, String>,
+        against query: FuzzyQuery
+    ) -> [ItemMatchResult<Item>] {
+        var buffer = makeBuffer()
+        var results: [ItemMatchResult<Item>] = []
+
+        for candidate in candidates {
+            if let match = score(candidate[keyPath: keyPath], against: query, buffer: &buffer) {
+                results.append(ItemMatchResult(item: candidate, match: match))
+            }
+        }
+
+        results.sort { $0.match.score > $1.match.score }
+        return results
+    }
+
+    /// Returns the top matches from a sequence of items, matching against a string
+    /// property extracted via key path, sorted by score descending.
+    ///
+    /// This is a convenience method that handles query preparation internally.
+    /// For scoring many queries against the same candidates, prefer the
+    /// ``prepare(_:)`` + ``topMatches(_:by:against:limit:)-3o7g8`` pattern instead.
+    ///
+    /// - Parameters:
+    ///   - candidates: The items to search.
+    ///   - keyPath: A key path to the string property to match against.
+    ///   - query: The query string to match against.
+    ///   - limit: Maximum number of results to return. Default is `10`.
+    /// - Returns: An array of ``ItemMatchResult`` sorted by score descending,
+    ///   containing at most `limit` elements.
+    public func topMatches<Item>(
+        _ candidates: some Sequence<Item>,
+        by keyPath: KeyPath<Item, String>,
+        against query: String,
+        limit: Int = 10
+    ) -> [ItemMatchResult<Item>] {
+        topMatches(candidates, by: keyPath, against: prepare(query), limit: limit)
+    }
+
+    /// Returns all matching items sorted by score descending, matching against a
+    /// string property extracted via key path.
+    ///
+    /// This is a convenience method that handles query preparation internally.
+    /// For scoring many queries against the same candidates, prefer the
+    /// ``prepare(_:)`` + ``matches(_:by:against:)-8skx7`` pattern instead.
+    ///
+    /// - Parameters:
+    ///   - candidates: The items to search.
+    ///   - keyPath: A key path to the string property to match against.
+    ///   - query: The query string to match against.
+    /// - Returns: An array of ``ItemMatchResult`` sorted by score descending.
+    public func matches<Item>(
+        _ candidates: some Sequence<Item>,
+        by keyPath: KeyPath<Item, String>,
+        against query: String
+    ) -> [ItemMatchResult<Item>] {
+        matches(candidates, by: keyPath, against: prepare(query))
+    }
+}

--- a/Tests/FuzzyMatchTests/KeyPathConvenienceTests.swift
+++ b/Tests/FuzzyMatchTests/KeyPathConvenienceTests.swift
@@ -1,0 +1,225 @@
+// ===----------------------------------------------------------------------===//
+//
+// This source file is part of the FuzzyMatch open source project
+//
+// Copyright (c) 2026 Ordo One, AB. and the FuzzyMatch project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ===----------------------------------------------------------------------===//
+
+@testable import FuzzyMatch
+import Testing
+
+private struct Instrument: Equatable, Hashable, Sendable {
+    let ticker: String
+    let name: String
+}
+
+private let instruments = [
+    Instrument(ticker: "AAPL", name: "Apple Inc"),
+    Instrument(ticker: "MSFT", name: "Microsoft Corporation"),
+    Instrument(ticker: "GOOG", name: "Alphabet Inc"),
+    Instrument(ticker: "AMZN", name: "Amazon.com Inc"),
+    Instrument(ticker: "META", name: "Meta Platforms Inc"),
+    Instrument(ticker: "TSLA", name: "Tesla Inc"),
+    Instrument(ticker: "JPM", name: "JPMorgan Chase & Co"),
+    Instrument(ticker: "GS", name: "Goldman Sachs Group Inc"),
+]
+
+// MARK: - topMatches by KeyPath Tests
+
+@Test func keyPathTopMatchesReturnsCorrectItems() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("apple")
+    let results = matcher.topMatches(instruments, by: \.name, against: query, limit: 3)
+    #expect(!results.isEmpty)
+    #expect(results[0].item.ticker == "AAPL")
+}
+
+@Test func keyPathTopMatchesSortedByScoreDescending() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("inc")
+    let results = matcher.topMatches(instruments, by: \.name, against: query, limit: 10)
+    for i in 1..<results.count {
+        #expect(results[i - 1].match.score >= results[i].match.score)
+    }
+}
+
+@Test func keyPathTopMatchesRespectsLimit() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("inc")
+    let results = matcher.topMatches(instruments, by: \.name, against: query, limit: 2)
+    #expect(results.count <= 2)
+}
+
+@Test func keyPathTopMatchesDefaultLimitIs10() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("inc")
+    let results = matcher.topMatches(instruments, by: \.name, against: query)
+    // Default limit is 10, we have 8 instruments so all matches should be returned
+    #expect(results.count <= 10)
+}
+
+@Test func keyPathTopMatchesEmptyWhenNoMatches() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("zzzzz")
+    let results = matcher.topMatches(instruments, by: \.name, against: query, limit: 5)
+    #expect(results.isEmpty)
+}
+
+@Test func keyPathTopMatchesEmptyCandidates() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("apple")
+    let results = matcher.topMatches([] as [Instrument], by: \.name, against: query, limit: 5)
+    #expect(results.isEmpty)
+}
+
+// MARK: - matches by KeyPath Tests
+
+@Test func keyPathMatchesReturnsAllMatchingItems() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("inc")
+    let results = matcher.matches(instruments, by: \.name, against: query)
+    #expect(!results.isEmpty)
+    // All results should be sorted by score descending
+    for i in 1..<results.count {
+        #expect(results[i - 1].match.score >= results[i].match.score)
+    }
+}
+
+@Test func keyPathMatchesEmptyForNoMatches() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("zzzzz")
+    let results = matcher.matches(instruments, by: \.name, against: query)
+    #expect(results.isEmpty)
+}
+
+@Test func keyPathMatchesEmptyCandidates() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("apple")
+    let results = matcher.matches([] as [Instrument], by: \.name, against: query)
+    #expect(results.isEmpty)
+}
+
+// MARK: - String Query Overloads
+
+@Test func keyPathStringQueryTopMatchesEquivalent() {
+    let matcher = FuzzyMatcher()
+    let queryStr = "apple"
+    let prepared = matcher.prepare(queryStr)
+
+    let fromPrepared = matcher.topMatches(instruments, by: \.name, against: prepared, limit: 5)
+    let fromString = matcher.topMatches(instruments, by: \.name, against: queryStr, limit: 5)
+
+    #expect(fromPrepared.count == fromString.count)
+    for i in 0..<fromPrepared.count {
+        #expect(fromPrepared[i].item == fromString[i].item,
+                "Item mismatch at index \(i)")
+        #expect(fromPrepared[i].match.score == fromString[i].match.score,
+                "Score mismatch at index \(i)")
+        #expect(fromPrepared[i].match.kind == fromString[i].match.kind,
+                "Kind mismatch at index \(i)")
+    }
+}
+
+@Test func keyPathStringQueryMatchesEquivalent() {
+    let matcher = FuzzyMatcher()
+    let queryStr = "inc"
+    let prepared = matcher.prepare(queryStr)
+
+    let fromPrepared = matcher.matches(instruments, by: \.name, against: prepared)
+    let fromString = matcher.matches(instruments, by: \.name, against: queryStr)
+
+    #expect(fromPrepared.count == fromString.count)
+    for i in 0..<fromPrepared.count {
+        #expect(fromPrepared[i].item == fromString[i].item,
+                "Item mismatch at index \(i)")
+        #expect(fromPrepared[i].match.score == fromString[i].match.score,
+                "Score mismatch at index \(i)")
+    }
+}
+
+// MARK: - Different Key Paths
+
+@Test func keyPathMatchesByTicker() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("AAPL")
+    let results = matcher.topMatches(instruments, by: \.ticker, against: query, limit: 3)
+    #expect(!results.isEmpty)
+    #expect(results[0].item.ticker == "AAPL")
+    #expect(results[0].match.kind == .exact)
+}
+
+@Test func keyPathDifferentKeyPathsDifferentResults() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("meta")
+
+    let byName = matcher.matches(instruments, by: \.name, against: query)
+    let byTicker = matcher.matches(instruments, by: \.ticker, against: query)
+
+    let nameItems = Set(byName.map { $0.item.ticker })
+    let tickerItems = Set(byTicker.map { $0.item.ticker })
+
+    // "meta" should match "Meta Platforms Inc" by name and "META" by ticker
+    #expect(nameItems.contains("META"))
+    #expect(tickerItems.contains("META"))
+}
+
+// MARK: - Equivalence with String API
+
+@Test func keyPathResultsMatchStringAPIResults() {
+    let matcher = FuzzyMatcher()
+    let queryStr = "gold"
+    let query = matcher.prepare(queryStr)
+
+    // Key-path API
+    let keyPathResults = matcher.matches(instruments, by: \.name, against: query)
+
+    // String API with extracted names
+    let names = instruments.map { $0.name }
+    let stringResults = matcher.matches(names, against: query)
+
+    #expect(keyPathResults.count == stringResults.count,
+            "Count mismatch: keyPath=\(keyPathResults.count) string=\(stringResults.count)")
+    for i in 0..<keyPathResults.count {
+        #expect(keyPathResults[i].item.name == stringResults[i].candidate,
+                "Candidate mismatch at index \(i)")
+        #expect(keyPathResults[i].match.score == stringResults[i].match.score,
+                "Score mismatch at index \(i)")
+        #expect(keyPathResults[i].match.kind == stringResults[i].match.kind,
+                "Kind mismatch at index \(i)")
+    }
+}
+
+// MARK: - Cross-method Consistency
+
+@Test func keyPathTopMatchesSubsetOfMatches() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("inc")
+
+    let all = matcher.matches(instruments, by: \.name, against: query)
+    let top3 = matcher.topMatches(instruments, by: \.name, against: query, limit: 3)
+
+    let allTop3 = Array(all.prefix(3))
+    #expect(top3.count == allTop3.count)
+    for i in 0..<top3.count {
+        #expect(top3[i].item == allTop3[i].item,
+                "Item mismatch at \(i): topMatches=\(top3[i].item) matches=\(allTop3[i].item)")
+        #expect(top3[i].match.score == allTop3[i].match.score,
+                "Score mismatch at \(i)")
+    }
+}
+
+@Test func keyPathTopMatchesLimitExceedingCountEqualsMatches() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("inc")
+
+    let all = matcher.matches(instruments, by: \.name, against: query)
+    let topAll = matcher.topMatches(instruments, by: \.name, against: query, limit: 1_000)
+
+    #expect(all.count == topAll.count)
+}


### PR DESCRIPTION
## Description

Add ItemMatchResult<Item> and key-path overloads of topMatches/matches so users can search collections of structured items (e.g., [Instrument]) by a string property (e.g., \.name) without manually extracting and reassociating strings.

I am opening this for feedback, I do not intend to submit for merging just yet.

```
let instruments = [
    Instrument(ticker: "AAPL", name: "Apple Inc"),
    Instrument(ticker: "MSFT", name: "Microsoft Corporation"),
    Instrument(ticker: "GOOG", name: "Alphabet Inc"),
]
let matcher = FuzzyMatcher()
let query = matcher.prepare("inc")
let all = matcher.matches(instruments, by: \.name, against: query)
```

## How Has This Been Tested?

Claude generated a handful of tests that are passing.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added DocC documentation (`///` comments) for any new public APIs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass (`swift test`)
- [x] If this is a performance-related change, I have included benchmark results (before/after)
