### PR TITLE
fix(patch): resolve overlapping exclusive access errors in library evolution mode

### DIFF
--- a/Sources/FuzzyMatch/FuzzyMatcher.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher.swift
@@ -344,14 +344,16 @@ public struct FuzzyMatcher: Sendable {
     ) -> ScoredMatch? {
         switch query.config.algorithm {
         case .smithWaterman(let swConfig):
-            return scoreSmithWatermanImpl(
-                candidateUTF8,
-                against: query,
-                swConfig: swConfig,
-                candidateStorage: &buffer.candidateStorage,
-                smithWatermanState: &buffer.smithWatermanState,
-                wordInitials: &buffer.wordInitials
-            )
+            return buffer.withSmithWatermanBuffers { candidateStorage, smithWatermanState, wordInitials in
+                scoreSmithWatermanImpl(
+                    candidateUTF8,
+                    against: query,
+                    swConfig: swConfig,
+                    candidateStorage: &candidateStorage,
+                    smithWatermanState: &smithWatermanState,
+                    wordInitials: &wordInitials
+                )
+            }
 
         case .editDistance(let edConfig):
             // Fast path for 1-character queries: single scan, no buffer needed.
@@ -366,16 +368,18 @@ public struct FuzzyMatcher: Sendable {
                     minScore: query.config.minScore
                 )
             }
-            return scoreImpl(
-                candidateUTF8,
-                against: query,
-                edConfig: edConfig,
-                candidateStorage: &buffer.candidateStorage,
-                editDistanceState: &buffer.editDistanceState,
-                matchPositions: &buffer.matchPositions,
-                alignmentState: &buffer.alignmentState,
-                wordInitials: &buffer.wordInitials
-            )
+            return buffer.withEditDistanceBuffers { candidateStorage, editDistanceState, matchPositions, alignmentState, wordInitials in
+                scoreImpl(
+                    candidateUTF8,
+                    against: query,
+                    edConfig: edConfig,
+                    candidateStorage: &candidateStorage,
+                    editDistanceState: &editDistanceState,
+                    matchPositions: &matchPositions,
+                    alignmentState: &alignmentState,
+                    wordInitials: &wordInitials
+                )
+            }
         }
     }
 

--- a/Sources/FuzzyMatch/ScoringBuffer.swift
+++ b/Sources/FuzzyMatch/ScoringBuffer.swift
@@ -71,11 +71,21 @@ internal struct CandidateStorage: Sendable {
     mutating func withMutableBuffers<R>(
         _ body: (UnsafeMutablePointer<UInt8>, UnsafeMutablePointer<Int32>) -> R
     ) -> R {
-        bytes.withUnsafeMutableBufferPointer { bytesPtr in
-            bonus.withUnsafeMutableBufferPointer { bonusPtr in
+        // Swap arrays into locals so the nested withUnsafeMutableBufferPointer
+        // calls operate on independent variables, avoiding overlapping exclusive
+        // accesses to `self` in library evolution mode. swap() is O(1) for arrays.
+        var localBytes: [UInt8] = []
+        var localBonus: [Int32] = []
+        swap(&localBytes, &bytes)
+        swap(&localBonus, &bonus)
+        let result = localBytes.withUnsafeMutableBufferPointer { bytesPtr in
+            localBonus.withUnsafeMutableBufferPointer { bonusPtr in
                 body(bytesPtr.baseAddress!, bonusPtr.baseAddress!)
             }
         }
+        swap(&localBytes, &bytes)
+        swap(&localBonus, &bonus)
+        return result
     }
 }
 
@@ -391,5 +401,43 @@ public struct ScoringBuffer: Sendable {
         highWaterCandidateLength = 0
         highWaterQueryLength = 0
         callsSinceLastCheck = 0
+    }
+
+    // MARK: - Disjoint Property Access
+
+    /// Provides simultaneous `inout` access to buffers needed by the edit distance pipeline.
+    ///
+    /// In library evolution mode, passing `&buffer.candidateStorage` and `&buffer.editDistanceState`
+    /// as separate `inout` arguments triggers an overlapping-access error. This method provides
+    /// a single exclusive access to `self` and projects its stored properties through a closure.
+    @inline(__always)
+    @inlinable
+    mutating func withEditDistanceBuffers<R>(
+        _ body: (
+            inout CandidateStorage,
+            inout EditDistanceState,
+            inout [Int],
+            inout AlignmentState,
+            inout [UInt8]
+        ) -> R
+    ) -> R {
+        body(&candidateStorage, &editDistanceState, &matchPositions, &alignmentState, &wordInitials)
+    }
+
+    /// Provides simultaneous `inout` access to buffers needed by the Smith-Waterman pipeline.
+    ///
+    /// In library evolution mode, passing `&buffer.candidateStorage` and `&buffer.smithWatermanState`
+    /// as separate `inout` arguments triggers an overlapping-access error. This method provides
+    /// a single exclusive access to `self` and projects its stored properties through a closure.
+    @inline(__always)
+    @inlinable
+    mutating func withSmithWatermanBuffers<R>(
+        _ body: (
+            inout CandidateStorage,
+            inout SmithWatermanState,
+            inout [UInt8]
+        ) -> R
+    ) -> R {
+        body(&candidateStorage, &smithWatermanState, &wordInitials)
     }
 }


### PR DESCRIPTION
Restructure buffer access patterns to avoid simultaneous inout borrows of sibling stored properties, which the compiler rejects in resilient (library evolution) builds where it cannot prove disjointness.

## Description

Include a summary of the change and which issue is fixed.

Fixes #issue-number

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added DocC documentation (`///` comments) for any new public APIs
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass (`swift test`)
- [ ] If this is a performance-related change, I have included benchmark results (before/after)
