### PR TITLE
fix(patch): resolve overlapping exclusive access in library evolution mode

### DIFF
--- a/Sources/FuzzyMatch/ScoringBuffer.swift
+++ b/Sources/FuzzyMatch/ScoringBuffer.swift
@@ -421,7 +421,15 @@ public struct ScoringBuffer: Sendable {
             inout [UInt8]
         ) -> R
     ) -> R {
-        body(&candidateStorage, &editDistanceState, &matchPositions, &alignmentState, &wordInitials)
+        withUnsafeMutablePointer(to: &self) { ptr in
+            body(
+                &ptr.pointee.candidateStorage,
+                &ptr.pointee.editDistanceState,
+                &ptr.pointee.matchPositions,
+                &ptr.pointee.alignmentState,
+                &ptr.pointee.wordInitials
+            )
+        }
     }
 
     /// Provides simultaneous `inout` access to buffers needed by the Smith-Waterman pipeline.
@@ -438,6 +446,12 @@ public struct ScoringBuffer: Sendable {
             inout [UInt8]
         ) -> R
     ) -> R {
-        body(&candidateStorage, &smithWatermanState, &wordInitials)
+        withUnsafeMutablePointer(to: &self) { ptr in
+            body(
+                &ptr.pointee.candidateStorage,
+                &ptr.pointee.smithWatermanState,
+                &ptr.pointee.wordInitials
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The `withEditDistanceBuffers`/`withSmithWatermanBuffers` helpers from #4 still had overlapping accesses to `self` — passing multiple `&self.X` arguments creates simultaneous exclusive accesses even within a method
- Fix: route through `withUnsafeMutablePointer(to: &self)` to take a single exclusive access and project stored properties via the pointer, bypassing the static exclusivity checker

## Test plan
- [x] Build passes with `-enable-library-evolution`
- [x] All 699 tests pass
- [x] SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)