### PR TITLE
feat(patch): Add FuzzySearch macOS example app

### DIFF
--- a/Examples/FuzzySearch/FuzzySearch.xcodeproj/project.pbxproj
+++ b/Examples/FuzzySearch/FuzzySearch.xcodeproj/project.pbxproj
@@ -1,0 +1,250 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4A0000000000000000000001 /* FuzzySearchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0000000000000000000001 /* FuzzySearchApp.swift */; };
+		4A0000000000000000000002 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0000000000000000000002 /* SearchViewModel.swift */; };
+		4A0000000000000000000003 /* FuzzyMatch in Frameworks */ = {isa = PBXBuildFile; productRef = CA0000000000000000000002 /* FuzzyMatch */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		5A0000000000000000000001 /* FuzzySearchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzySearchApp.swift; sourceTree = "<group>"; };
+		5A0000000000000000000002 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		5A0000000000000000000003 /* FuzzySearch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FuzzySearch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7A0000000000000000000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A0000000000000000000003 /* FuzzyMatch in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6A0000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				6A0000000000000000000002 /* FuzzySearch */,
+				6A0000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6A0000000000000000000002 /* FuzzySearch */ = {
+			isa = PBXGroup;
+			children = (
+				5A0000000000000000000001 /* FuzzySearchApp.swift */,
+				5A0000000000000000000002 /* SearchViewModel.swift */,
+			);
+			path = FuzzySearch;
+			sourceTree = "<group>";
+		};
+		6A0000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5A0000000000000000000003 /* FuzzySearch.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8A0000000000000000000001 /* FuzzySearch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA0000000000000000000002 /* Build configuration list for PBXNativeTarget "FuzzySearch" */;
+			buildPhases = (
+				7A0000000000000000000001 /* Sources */,
+				7A0000000000000000000002 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FuzzySearch;
+			packageProductDependencies = (
+				CA0000000000000000000002 /* FuzzyMatch */,
+			);
+			productName = FuzzySearch;
+			productReference = 5A0000000000000000000003 /* FuzzySearch.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9A0000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+			};
+			buildConfigurationList = BA0000000000000000000001 /* Build configuration list for PBXProject "FuzzySearch" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6A0000000000000000000001;
+			packageReferences = (
+				CA0000000000000000000001 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			productRefGroup = 6A0000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8A0000000000000000000001 /* FuzzySearch */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7A0000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A0000000000000000000001 /* FuzzySearchApp.swift in Sources */,
+				4A0000000000000000000002 /* SearchViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AA0000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AA0000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		AA0000000000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.FuzzySearch;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		AA0000000000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.FuzzySearch;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BA0000000000000000000001 /* Build configuration list for PBXProject "FuzzySearch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA0000000000000000000001 /* Debug */,
+				AA0000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BA0000000000000000000002 /* Build configuration list for PBXNativeTarget "FuzzySearch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA0000000000000000000003 /* Debug */,
+				AA0000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		CA0000000000000000000001 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../..";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		CA0000000000000000000002 /* FuzzyMatch */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FuzzyMatch;
+		};
+/* End XCSwiftPackageProductDependency section */
+
+	};
+	rootObject = 9A0000000000000000000001 /* Project object */;
+}

--- a/Examples/FuzzySearch/FuzzySearch.xcodeproj/xcshareddata/xcschemes/FuzzySearch.xcscheme
+++ b/Examples/FuzzySearch/FuzzySearch.xcodeproj/xcshareddata/xcschemes/FuzzySearch.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8A0000000000000000000001"
+               BuildableName = "FuzzySearch.app"
+               BlueprintName = "FuzzySearch"
+               ReferencedContainer = "container:FuzzySearch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8A0000000000000000000001"
+            BuildableName = "FuzzySearch.app"
+            BlueprintName = "FuzzySearch"
+            ReferencedContainer = "container:FuzzySearch.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8A0000000000000000000001"
+            BuildableName = "FuzzySearch.app"
+            BlueprintName = "FuzzySearch"
+            ReferencedContainer = "container:FuzzySearch.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/FuzzySearch/FuzzySearch/FuzzySearchApp.swift
+++ b/Examples/FuzzySearch/FuzzySearch/FuzzySearchApp.swift
@@ -16,19 +16,29 @@ import SwiftUI
 
 @main
 struct FuzzySearchApp: App {
+    @State private var viewModel = SearchViewModel()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(viewModel: viewModel)
                 .frame(minWidth: 700, minHeight: 500)
         }
         .defaultSize(width: 900, height: 650)
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("Open...") {
+                    viewModel.openFile()
+                }
+                .keyboardShortcut("o")
+            }
+        }
     }
 }
 
 // MARK: - Content View
 
 struct ContentView: View {
-    @State private var viewModel = SearchViewModel()
+    @Bindable var viewModel: SearchViewModel
 
     var body: some View {
         NavigationStack {
@@ -47,9 +57,11 @@ struct ContentView: View {
                     )
                 } else if viewModel.query.isEmpty {
                     ContentUnavailableView(
-                        "Search Instruments",
+                        "Search",
                         systemImage: "magnifyingglass",
-                        description: Text("\(viewModel.corpusSize.formatted()) instruments loaded")
+                        description: Text(
+                            "\(viewModel.corpusSize.formatted()) entries loaded from \(viewModel.dataSourceName)"
+                        )
                     )
                 } else if viewModel.results.isEmpty && viewModel.searchTimeMS != nil {
                     ContentUnavailableView.search(text: viewModel.query)
@@ -60,7 +72,7 @@ struct ContentView: View {
             .navigationTitle("FuzzySearch")
             .searchable(
                 text: $viewModel.query,
-                prompt: "Search \(viewModel.corpusSize.formatted()) instruments..."
+                prompt: "Search \(viewModel.corpusSize.formatted()) entries..."
             )
             .onChange(of: viewModel.query) { _, _ in
                 viewModel.scheduleSearch()
@@ -136,14 +148,16 @@ struct ResultRow: View {
                 Text(result.highlightedName)
                     .font(.body)
 
-                HStack(spacing: 12) {
-                    Label(result.instrument.symbol, systemImage: "tag")
-                    Label(result.instrument.isin, systemImage: "number")
-                    Label(result.instrument.productClass, systemImage: "square.grid.2x2")
+                if !result.instrument.symbol.isEmpty {
+                    HStack(spacing: 12) {
+                        Label(result.instrument.symbol, systemImage: "tag")
+                        Label(result.instrument.isin, systemImage: "number")
+                        Label(result.instrument.productClass, systemImage: "square.grid.2x2")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
                 }
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
             }
 
             Spacer()

--- a/Examples/FuzzySearch/FuzzySearch/FuzzySearchApp.swift
+++ b/Examples/FuzzySearch/FuzzySearch/FuzzySearchApp.swift
@@ -1,0 +1,180 @@
+// ===----------------------------------------------------------------------===//
+//
+// This source file is part of the FuzzyMatch open source project
+//
+// Copyright (c) 2026 Ordo One, AB. and the FuzzyMatch project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ===----------------------------------------------------------------------===//
+
+import FuzzyMatch
+import SwiftUI
+
+@main
+struct FuzzySearchApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .frame(minWidth: 700, minHeight: 500)
+        }
+        .defaultSize(width: 900, height: 650)
+    }
+}
+
+// MARK: - Content View
+
+struct ContentView: View {
+    @State private var viewModel = SearchViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading {
+                    ContentUnavailableView {
+                        ProgressView()
+                    } description: {
+                        Text("Loading corpus...")
+                    }
+                } else if let error = viewModel.errorMessage {
+                    ContentUnavailableView(
+                        "Error",
+                        systemImage: "exclamationmark.triangle",
+                        description: Text(error)
+                    )
+                } else if viewModel.query.isEmpty {
+                    ContentUnavailableView(
+                        "Search Instruments",
+                        systemImage: "magnifyingglass",
+                        description: Text("\(viewModel.corpusSize.formatted()) instruments loaded")
+                    )
+                } else if viewModel.results.isEmpty && viewModel.searchTimeMS != nil {
+                    ContentUnavailableView.search(text: viewModel.query)
+                } else {
+                    resultsList
+                }
+            }
+            .navigationTitle("FuzzySearch")
+            .searchable(
+                text: $viewModel.query,
+                prompt: "Search \(viewModel.corpusSize.formatted()) instruments..."
+            )
+            .onChange(of: viewModel.query) { _, _ in
+                viewModel.scheduleSearch()
+            }
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Picker("Algorithm", selection: $viewModel.algorithmChoice) {
+                        ForEach(AlgorithmChoice.allCases) { choice in
+                            Text(choice.rawValue).tag(choice)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .help("Matching algorithm")
+                }
+            }
+            .task {
+                viewModel.loadCorpus()
+            }
+        }
+    }
+
+    private var resultsList: some View {
+        List {
+            ForEach(viewModel.results) { result in
+                ResultRow(result: result)
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            statusBar
+        }
+    }
+
+    private var statusBar: some View {
+        HStack(spacing: 16) {
+            if let ms = viewModel.searchTimeMS {
+                Label(
+                    "\(viewModel.results.count) results",
+                    systemImage: "list.number"
+                )
+                Label(
+                    String(format: "%.1f ms", ms),
+                    systemImage: "clock"
+                )
+            }
+            Spacer()
+            Text(viewModel.algorithmChoice.rawValue)
+                .foregroundStyle(.tertiary)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal)
+        .padding(.vertical, 6)
+        .background(.ultraThinMaterial)
+    }
+}
+
+// MARK: - Result Row
+
+struct ResultRow: View {
+    let result: SearchResult
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Rank badge
+            Text("\(result.rank)")
+                .font(.caption.monospacedDigit().bold())
+                .foregroundStyle(.white)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(.secondary))
+
+            // Main content
+            VStack(alignment: .leading, spacing: 3) {
+                Text(result.highlightedName)
+                    .font(.body)
+
+                HStack(spacing: 12) {
+                    Label(result.instrument.symbol, systemImage: "tag")
+                    Label(result.instrument.isin, systemImage: "number")
+                    Label(result.instrument.productClass, systemImage: "square.grid.2x2")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+
+            Spacer()
+
+            // Score and match kind
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(result.score, format: .percent.precision(.fractionLength(1)))
+                    .font(.caption.monospacedDigit().bold())
+                    .foregroundStyle(.secondary)
+
+                Text(result.kind.description.capitalized)
+                    .font(.caption2.bold())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule().fill(kindColor.opacity(0.12))
+                    )
+                    .foregroundStyle(kindColor)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var kindColor: Color {
+        switch result.kind {
+        case .exact: .green
+        case .prefix: .blue
+        case .substring: .purple
+        case .acronym: .orange
+        case .alignment: .teal
+        @unknown default: .gray
+        }
+    }
+}

--- a/Examples/FuzzySearch/FuzzySearch/SearchViewModel.swift
+++ b/Examples/FuzzySearch/FuzzySearch/SearchViewModel.swift
@@ -59,6 +59,7 @@ final class SearchViewModel {
     var corpusSize = 0
     var isLoading = true
     var errorMessage: String?
+    var dataSourceName = "instruments"
     var algorithmChoice: AlgorithmChoice = .editDistance {
         didSet {
             matcher = FuzzyMatcher(config: algorithmChoice.config)
@@ -100,6 +101,7 @@ final class SearchViewModel {
             let url = URL(fileURLWithPath: path)
             if let data = try? String(contentsOf: url, encoding: .utf8) {
                 parseCorpus(data)
+                dataSourceName = url.lastPathComponent
                 isLoading = false
                 return
             }
@@ -122,6 +124,48 @@ final class SearchViewModel {
         }
 
         isLoading = false
+    }
+
+    func openFile() {
+        let panel = NSOpenPanel()
+        panel.title = "Open File"
+        panel.allowedContentTypes = [.plainText]
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url,
+            let data = try? String(contentsOf: url, encoding: .utf8)
+        else {
+            return
+        }
+
+        resetData()
+
+        let lines = data.split(separator: "\n", omittingEmptySubsequences: true)
+        instruments.reserveCapacity(lines.count)
+
+        for (i, line) in lines.enumerated() {
+            instruments.append(
+                Instrument(id: i, symbol: "", name: String(line), isin: "", productClass: ""))
+        }
+
+        candidateNames = instruments.map(\.name)
+        nameToFirstIndex = Dictionary(
+            candidateNames.enumerated().map { ($0.element, $0.offset) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        corpusSize = instruments.count
+        dataSourceName = url.lastPathComponent
+        isLoading = false
+    }
+
+    private func resetData() {
+        instruments = []
+        candidateNames = []
+        nameToFirstIndex = [:]
+        results = []
+        searchTimeMS = nil
+        query = ""
+        errorMessage = nil
     }
 
     private func parseCorpus(_ data: String) {

--- a/Examples/FuzzySearch/FuzzySearch/SearchViewModel.swift
+++ b/Examples/FuzzySearch/FuzzySearch/SearchViewModel.swift
@@ -1,0 +1,233 @@
+// ===----------------------------------------------------------------------===//
+//
+// This source file is part of the FuzzyMatch open source project
+//
+// Copyright (c) 2026 Ordo One, AB. and the FuzzyMatch project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ===----------------------------------------------------------------------===//
+
+import AppKit
+import FuzzyMatch
+import SwiftUI
+
+// MARK: - Data Models
+
+struct Instrument: Identifiable, Sendable {
+    let id: Int
+    let symbol: String
+    let name: String
+    let isin: String
+    let productClass: String
+}
+
+struct SearchResult: Identifiable {
+    let id: Int
+    let rank: Int
+    let instrument: Instrument
+    let score: Double
+    let kind: MatchKind
+    let highlightedName: AttributedString
+}
+
+enum AlgorithmChoice: String, CaseIterable, Identifiable {
+    case editDistance = "Edit Distance"
+    case smithWaterman = "Smith-Waterman"
+
+    var id: Self { self }
+
+    var config: MatchConfig {
+        switch self {
+        case .editDistance: .editDistance
+        case .smithWaterman: .smithWaterman
+        }
+    }
+}
+
+// MARK: - View Model
+
+@MainActor
+@Observable
+final class SearchViewModel {
+    var query = ""
+    var results: [SearchResult] = []
+    var searchTimeMS: Double?
+    var corpusSize = 0
+    var isLoading = true
+    var errorMessage: String?
+    var algorithmChoice: AlgorithmChoice = .editDistance {
+        didSet {
+            matcher = FuzzyMatcher(config: algorithmChoice.config)
+            scheduleSearch()
+        }
+    }
+
+    private var instruments: [Instrument] = []
+    private var candidateNames: [String] = []
+    private var nameToFirstIndex: [String: Int] = [:]
+    private var searchTask: Task<Void, Never>?
+    private var matcher = FuzzyMatcher()
+
+    // MARK: - Corpus Loading
+
+    /// Resolves the corpus path relative to this source file at compile time,
+    /// so the app finds the data regardless of working directory (e.g. when launched from Xcode).
+    private static let corpusURL: URL = {
+        // #filePath → .../Examples/FuzzySearch/FuzzySearch/SearchViewModel.swift
+        // Navigate up to the FuzzyMatch project root, then into Resources/
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // FuzzySearch/
+            .deletingLastPathComponent()   // Examples/FuzzySearch/
+            .deletingLastPathComponent()   // Examples/
+            .deletingLastPathComponent()   // FuzzyMatch project root
+            .appendingPathComponent("Resources/instruments-export.tsv")
+    }()
+
+    func loadCorpus() {
+        isLoading = true
+
+        let paths = [
+            Self.corpusURL.path,
+            "Resources/instruments-export.tsv",
+            "../Resources/instruments-export.tsv",
+        ]
+
+        for path in paths {
+            let url = URL(fileURLWithPath: path)
+            if let data = try? String(contentsOf: url, encoding: .utf8) {
+                parseCorpus(data)
+                isLoading = false
+                return
+            }
+        }
+
+        // Fallback: open file panel
+        let panel = NSOpenPanel()
+        panel.title = "Select instruments-export.tsv"
+        panel.message = "Locate the corpus file (Resources/instruments-export.tsv)"
+        panel.allowedContentTypes = [.plainText]
+        panel.canChooseDirectories = false
+
+        if panel.runModal() == .OK, let url = panel.url,
+            let data = try? String(contentsOf: url, encoding: .utf8)
+        {
+            parseCorpus(data)
+        } else {
+            errorMessage =
+                "No corpus file loaded.\nRun from the FuzzyMatch project root:\n  swift run --package-path Examples FuzzySearch"
+        }
+
+        isLoading = false
+    }
+
+    private func parseCorpus(_ data: String) {
+        let lines = data.split(separator: "\n").dropFirst()  // skip header
+        instruments.reserveCapacity(lines.count)
+
+        for (i, line) in lines.enumerated() {
+            let cols = line.split(separator: "\t", maxSplits: 3)
+            guard cols.count >= 4 else { continue }
+            instruments.append(
+                Instrument(
+                    id: i,
+                    symbol: String(cols[0]),
+                    name: String(cols[1]),
+                    isin: String(cols[2]),
+                    productClass: String(cols[3])
+                ))
+        }
+
+        candidateNames = instruments.map(\.name)
+
+        for (i, name) in candidateNames.enumerated() {
+            if nameToFirstIndex[name] == nil {
+                nameToFirstIndex[name] = i
+            }
+        }
+
+        corpusSize = instruments.count
+    }
+
+    // MARK: - Search
+
+    func scheduleSearch() {
+        searchTask?.cancel()
+
+        let q = query.trimmingCharacters(in: .whitespaces)
+        guard !q.isEmpty else {
+            results = []
+            searchTimeMS = nil
+            return
+        }
+
+        let matcher = self.matcher
+        let candidateNames = self.candidateNames
+        let instruments = self.instruments
+        let nameToFirstIndex = self.nameToFirstIndex
+
+        searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(100))
+            guard !Task.isCancelled else { return }
+
+            let (newResults, ms) = Self.performSearch(
+                query: q,
+                matcher: matcher,
+                candidateNames: candidateNames,
+                instruments: instruments,
+                nameToFirstIndex: nameToFirstIndex
+            )
+
+            guard !Task.isCancelled else { return }
+            self.results = newResults
+            self.searchTimeMS = ms
+        }
+    }
+
+    private nonisolated static func performSearch(
+        query: String,
+        matcher: FuzzyMatcher,
+        candidateNames: [String],
+        instruments: [Instrument],
+        nameToFirstIndex: [String: Int]
+    ) -> ([SearchResult], Double) {
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        let prepared = matcher.prepare(query)
+        let topMatches = matcher.topMatches(candidateNames, against: prepared, limit: 20)
+
+        let elapsed = clock.now - start
+        let ms =
+            Double(elapsed.components.seconds) * 1000
+            + Double(elapsed.components.attoseconds) / 1_000_000_000_000_000
+
+        let searchResults: [SearchResult] = topMatches.enumerated().compactMap { rank, matchResult in
+            let highlighted = matcher.attributedHighlight(
+                matchResult.candidate,
+                against: prepared
+            ) { container in
+                container.foregroundColor = .orange
+                container.font = .body.bold()
+                container.underlineStyle = .single
+                container.underlineColor = .orange
+            }
+
+            guard let idx = nameToFirstIndex[matchResult.candidate] else { return nil }
+
+            return SearchResult(
+                id: rank,
+                rank: rank + 1,
+                instrument: instruments[idx],
+                score: matchResult.match.score,
+                kind: matchResult.match.kind,
+                highlightedName: highlighted ?? AttributedString(matchResult.candidate)
+            )
+        }
+
+        return (searchResults, ms)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ for result in top3 {
 }
 ```
 
+## Try It — Interactive Search App
+
+The `Examples/FuzzySearch/` directory contains a macOS app for exploring how FuzzyMatch works interactively. It loads a 271K financial instrument corpus and live-searches as you type, showing the top 20 results with highlighted matched characters. Switch between Edit Distance and Smith-Waterman algorithms to see how they rank differently, or use File > Open (Cmd+O) to load your own newline-delimited data.
+
+<img width="1012" height="762" alt="FuzzySearch example app" src="https://github.com/user-attachments/assets/e3b056d9-1aac-4f06-8d64-5b9c9aee0f73" />
+
+Open the Xcode project and hit Run:
+
+```bash
+open Examples/FuzzySearch/FuzzySearch.xcodeproj
+```
+
 ## Usage
 
 ### Convenience API


### PR DESCRIPTION
## Summary
- Self-contained Xcode project under `Examples/FuzzySearch/` — open `FuzzySearch.xcodeproj` and hit Run
- Loads the full 271K instrument corpus on startup, live-searches with 100ms debounce, displays top 20 hits
- Uses `attributedHighlight` API to style matched characters (bold orange + underline)
- Toolbar picker to switch between Edit Distance and Smith-Waterman algorithms live
- **File > Open (Cmd+O)** to load any plain text file where each line is a searchable entry
- Local package dependency on FuzzyMatch resolved automatically by Xcode

<img width="1012" height="762" alt="image" src="https://github.com/user-attachments/assets/e3b056d9-1aac-4f06-8d64-5b9c9aee0f73" />

## Test plan
- [ ] Open `Examples/FuzzySearch/FuzzySearch.xcodeproj` in Xcode and build/run
- [ ] Verify corpus loads (status shows ~271K entries)
- [ ] Type a query and confirm results appear after debounce with highlighted matches
- [ ] Switch algorithm via toolbar picker and verify results update
- [ ] Use File > Open to load a plain text file and verify search works against it
- [ ] Verify instrument metadata row hides for plain text files

🤖 Generated with [Claude Code](https://claude.com/claude-code)