### PR TITLE
fix: exact substring ranking behind strong near-prefix matches

### DIFF
--- a/Sources/FuzzyMatch/FuzzyMatcher.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher.swift
@@ -694,18 +694,35 @@ public struct FuzzyMatcher: Sendable {
     ) {
         let queryLength = query.lowercased.count
 
-        // Skip when prefix match is strong or prefix distance is 0
-        // (prefix score with recovery 0.9 always beats substring with 0.8)
-        guard state.bestScore < 0.7 && prefixDistance != 0 else { return }
+        // Skip only when the prefix is exact. For strong near-prefix matches,
+        // keep the fast path unless an exact substring can compete.
+        guard prefixDistance != 0 else { return }
 
-        let substringDist = substringEditDistance(
-            query: querySpan,
-            candidate: candidateSpan,
-            state: &editDistanceState,
-            maxEditDistance: state.effectiveMaxEditDistance
-        )
+        let exactSubstringStart: Int?
+        if state.bestScore >= 0.7 {
+            let contiguousStart = findContiguousSubstring(
+                query: querySpan,
+                candidate: candidateSpan,
+                boundaryMask: state.boundaryMask
+            )
+            guard contiguousStart >= 0 else { return }
+            exactSubstringStart = contiguousStart
+        } else {
+            exactSubstringStart = nil
+        }
 
-        guard let distance = substringDist else { return }
+        let distance: Int
+        if exactSubstringStart != nil {
+            distance = 0
+        } else {
+            guard let substringDist = substringEditDistance(
+                query: querySpan,
+                candidate: candidateSpan,
+                state: &editDistanceState,
+                maxEditDistance: state.effectiveMaxEditDistance
+            ) else { return }
+            distance = substringDist
+        }
 
         // Short query same-length restriction (see scorePrefix for rationale).
         if queryLength <= 3 && distance > 0 && candidateLength != queryLength {
@@ -721,6 +738,30 @@ public struct FuzzyMatcher: Sendable {
 
         // Calculate bonuses using cached or fresh DP-optimal alignment
         if state.needsAlignment {
+            // Prefix scoring may have cached a different near-match alignment.
+            // Exact substrings should use their contiguous occurrence for bonuses
+            // and whole-word recovery.
+            if distance == 0 {
+                let contiguousStart = exactSubstringStart ?? findContiguousSubstring(
+                    query: querySpan,
+                    candidate: candidateSpan,
+                    boundaryMask: state.boundaryMask
+                )
+                if contiguousStart >= 0 {
+                    for i in 0..<queryLength {
+                        matchPositions[i] = contiguousStart + i
+                    }
+                    state.cachedPositionCount = queryLength
+                    state.cachedBonus = calculateBonuses(
+                        matchPositions: matchPositions,
+                        positionCount: queryLength,
+                        candidateBytes: candidateSpan,
+                        boundaryMask: state.boundaryMask,
+                        config: edConfig
+                    )
+                }
+            }
+
             if state.cachedPositionCount < 0 {
                 // For short queries with exact substring, try contiguous recovery
                 if queryLength <= 4 {
@@ -730,25 +771,6 @@ public struct FuzzyMatcher: Sendable {
                         boundaryMask: state.boundaryMask,
                         positions: &matchPositions
                     )
-
-                    // If exact substring exists but greedy found scattered positions,
-                    // scan for a contiguous occurrence (better bonuses + whole-word recovery)
-                    if distance == 0 && positionCount == queryLength {
-                        let firstPos = matchPositions[0]
-                        let lastPos = matchPositions[positionCount - 1]
-                        if lastPos - firstPos + 1 != queryLength {
-                            let contiguousStart = findContiguousSubstring(
-                                query: querySpan,
-                                candidate: candidateSpan,
-                                boundaryMask: state.boundaryMask
-                            )
-                            if contiguousStart >= 0 {
-                                for i in 0..<queryLength {
-                                    matchPositions[i] = contiguousStart + i
-                                }
-                            }
-                        }
-                    }
 
                     state.cachedPositionCount = positionCount
                     state.cachedBonus = positionCount > 0 ? calculateBonuses(

--- a/Sources/FuzzyMatch/FuzzyMatcher.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher.swift
@@ -694,27 +694,23 @@ public struct FuzzyMatcher: Sendable {
     ) {
         let queryLength = query.lowercased.count
 
-        // Skip only when the prefix is exact. For strong near-prefix matches,
-        // keep the fast path unless an exact substring can compete.
+        // Skip only when the prefix is exact. Otherwise, first check whether an
+        // exact substring can compete before falling back to fuzzy substring DP.
         guard prefixDistance != 0 else { return }
 
-        let exactSubstringStart: Int?
-        if state.bestScore >= 0.7 {
-            let contiguousStart = findContiguousSubstring(
-                query: querySpan,
-                candidate: candidateSpan,
-                boundaryMask: state.boundaryMask
-            )
-            guard contiguousStart >= 0 else { return }
-            exactSubstringStart = contiguousStart
-        } else {
-            exactSubstringStart = nil
-        }
+        let contiguousStart = findContiguousSubstring(
+            query: querySpan,
+            candidate: candidateSpan,
+            boundaryMask: state.boundaryMask
+        )
 
         let distance: Int
-        if exactSubstringStart != nil {
+        if contiguousStart >= 0 {
             distance = 0
         } else {
+            // Preserve the strong-prefix fast path: only fuzzy-score substrings
+            // when prefix scoring did not already find a good match.
+            guard state.bestScore < 0.7 else { return }
             guard let substringDist = substringEditDistance(
                 query: querySpan,
                 candidate: candidateSpan,
@@ -742,11 +738,6 @@ public struct FuzzyMatcher: Sendable {
             // Exact substrings should use their contiguous occurrence for bonuses
             // and whole-word recovery.
             if distance == 0 {
-                let contiguousStart = exactSubstringStart ?? findContiguousSubstring(
-                    query: querySpan,
-                    candidate: candidateSpan,
-                    boundaryMask: state.boundaryMask
-                )
                 if contiguousStart >= 0 {
                     for i in 0..<queryLength {
                         matchPositions[i] = contiguousStart + i

--- a/Sources/FuzzyMatch/FuzzyMatcher.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher.swift
@@ -737,20 +737,18 @@ public struct FuzzyMatcher: Sendable {
             // Prefix scoring may have cached a different near-match alignment.
             // Exact substrings should use their contiguous occurrence for bonuses
             // and whole-word recovery.
-            if distance == 0 {
-                if contiguousStart >= 0 {
-                    for i in 0..<queryLength {
-                        matchPositions[i] = contiguousStart + i
-                    }
-                    state.cachedPositionCount = queryLength
-                    state.cachedBonus = calculateBonuses(
-                        matchPositions: matchPositions,
-                        positionCount: queryLength,
-                        candidateBytes: candidateSpan,
-                        boundaryMask: state.boundaryMask,
-                        config: edConfig
-                    )
+            if distance == 0, contiguousStart >= 0 {
+                for i in 0..<queryLength {
+                    matchPositions[i] = contiguousStart + i
                 }
+                state.cachedPositionCount = queryLength
+                state.cachedBonus = calculateBonuses(
+                    matchPositions: matchPositions,
+                    positionCount: queryLength,
+                    candidateBytes: candidateSpan,
+                    boundaryMask: state.boundaryMask,
+                    config: edConfig
+                )
             }
 
             if state.cachedPositionCount < 0 {

--- a/Tests/FuzzyMatchTests/RankingQualityTests.swift
+++ b/Tests/FuzzyMatchTests/RankingQualityTests.swift
@@ -87,6 +87,17 @@ private func assertRanksHigher(
     assertRanksHigher(query: "config", higher: "configuration", lower: "configurable_item")
 }
 
+@Test func exactSubstringRanksAboveNearPrefixMatches() {
+    let results = rank("alpd", against: [
+        "Alpha - Demo One",
+        "Alpine Delta - User",
+        "Alpine Delta - Account (alpd)"
+    ])
+
+    #expect(results.count == 3)
+    #expect(results[0].candidate == "Alpine Delta - Account (alpd)")
+}
+
 // MARK: - Typo Tolerance
 
 @Test func typoUsrMatchesUser() {


### PR DESCRIPTION
## Description

Fix exact substring ranking when a strong but non-exact prefix match is found first.

Previously, substring scoring was skipped once prefix scoring produced a score above the internal strong-match threshold. That could cause an exact substring later in the candidate to be ignored, allowing near-prefix matches to rank higher than a candidate containing the query exactly.

This change preserves the existing fast path for strong prefix matches, but lets an exact contiguous substring compete when present. It reuses the existing contiguous substring helper and avoids running the full substring edit-distance path for strong near-prefix matches unless needed.

## How Has This Been Tested?

Ran the focused regression test: `swift test --filter exactSubstringRanksAboveNearPrefixMatches`

Ran the full test suite: `swift test`

Result: `808 tests` passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added DocC documentation (`///` comments) for any new public APIs
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass (`swift test`)
- [x] If this is a performance-related change, I have included benchmark results (before/after)
