### PR TITLE
feat: add enableSubsequenceMatching to EditDistanceConfig

### DIFF
--- a/Examples/FuzzySearch/FuzzySearch.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/FuzzySearch/FuzzySearch.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/FuzzyMatch/FuzzyMatcher.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher.swift
@@ -535,7 +535,7 @@ public struct FuzzyMatcher: Sendable {
                 )
 
                 // Phase 5: Subsequence scoring
-                if edConfig.enableSubsequenceMatching {
+                if edConfig.isSubsequenceMatchingEnabled {
                     scoreSubsequence(
                         querySpan: querySpan,
                         candidateSpan: candidateSpan,

--- a/Sources/FuzzyMatch/FuzzyMatcher.swift
+++ b/Sources/FuzzyMatch/FuzzyMatcher.swift
@@ -535,16 +535,18 @@ public struct FuzzyMatcher: Sendable {
                 )
 
                 // Phase 5: Subsequence scoring
-                scoreSubsequence(
-                    querySpan: querySpan,
-                    candidateSpan: candidateSpan,
-                    query: query,
-                    edConfig: edConfig,
-                    candidateLength: actualCandidateLength,
-                    state: &state,
-                    matchPositions: &matchPositions,
-                    alignmentState: &alignmentState
-                )
+                if edConfig.enableSubsequenceMatching {
+                    scoreSubsequence(
+                        querySpan: querySpan,
+                        candidateSpan: candidateSpan,
+                        query: query,
+                        edConfig: edConfig,
+                        candidateLength: actualCandidateLength,
+                        state: &state,
+                        matchPositions: &matchPositions,
+                        alignmentState: &alignmentState
+                    )
+                }
 
                 // Phase 6: Acronym scoring
                 scoreAcronym(

--- a/Sources/FuzzyMatch/MatchConfig.swift
+++ b/Sources/FuzzyMatch/MatchConfig.swift
@@ -238,6 +238,7 @@ public enum GapPenalty: Sendable, Equatable, Codable {
 /// | Favor early matches | Increase `firstMatchBonus` to `0.2` |
 /// | Tight matches only | Use `.affine(open: 0.05, extend: 0.01)` |
 /// | Pure edit distance | Set all bonuses to `0.0`, `gapPenalty: .none` |
+/// | Literal `contains` | `maxEditDistance: 0, acronymWeight: 0, enableSubsequenceMatching: false` |
 ///
 /// ## Gap Penalty Strategies
 ///
@@ -481,6 +482,28 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
     /// - `< 1.0`: Reduce acronym match scores
     public var acronymWeight: Double
 
+    /// Whether to fall back to gap-based subsequence matching.
+    ///
+    /// When `true` (default), a query whose characters all appear in order but not
+    /// contiguously (e.g. "usd" in "indUS holDing") still matches, scored by how tightly
+    /// the characters cluster. When `false`, the subsequence phase is skipped entirely, so
+    /// only exact, prefix, and contiguous substring matches survive.
+    ///
+    /// Disable this for *literal* matching where the query must appear as a contiguous run.
+    /// Combined with `maxEditDistance: 0` and `acronymWeight: 0`, it makes the matcher a
+    /// case- and diacritic-insensitive `contains` — a non-`nil` result then means the query
+    /// occurs as a contiguous substring.
+    ///
+    /// ```swift
+    /// // A `contains` predicate that won't match "usd" against "indUS holDing"
+    /// let config = EditDistanceConfig(
+    ///     maxEditDistance: 0,
+    ///     acronymWeight: 0,
+    ///     enableSubsequenceMatching: false
+    /// )
+    /// ```
+    public var enableSubsequenceMatching: Bool
+
     /// The default edit distance configuration.
     public static let `default` = Self()
 
@@ -513,6 +536,7 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
     ///   - firstMatchBonusRange: Max position for first-match bonus. Default is `10`.
     ///   - lengthPenalty: Penalty per excess character in the candidate. Default is `0.003`.
     ///   - acronymWeight: Weight for acronym matches. Default is `1.0`.
+    ///   - enableSubsequenceMatching: Whether to fall back to gap-based subsequence matching. Default is `true`.
     ///
     /// ## Example
     ///
@@ -555,7 +579,8 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
         firstMatchBonus: Double = 0.15,
         firstMatchBonusRange: Int = 10,
         lengthPenalty: Double = 0.003,
-        acronymWeight: Double = 1.0
+        acronymWeight: Double = 1.0,
+        enableSubsequenceMatching: Bool = true
     ) {
         self.maxEditDistance = maxEditDistance
         self.longQueryMaxEditDistance = longQueryMaxEditDistance
@@ -569,6 +594,7 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
         self.firstMatchBonusRange = firstMatchBonusRange
         self.lengthPenalty = lengthPenalty
         self.acronymWeight = acronymWeight
+        self.enableSubsequenceMatching = enableSubsequenceMatching
     }
 }
 

--- a/Sources/FuzzyMatch/MatchConfig.swift
+++ b/Sources/FuzzyMatch/MatchConfig.swift
@@ -238,7 +238,7 @@ public enum GapPenalty: Sendable, Equatable, Codable {
 /// | Favor early matches | Increase `firstMatchBonus` to `0.2` |
 /// | Tight matches only | Use `.affine(open: 0.05, extend: 0.01)` |
 /// | Pure edit distance | Set all bonuses to `0.0`, `gapPenalty: .none` |
-/// | Literal `contains` | `maxEditDistance: 0, acronymWeight: 0, enableSubsequenceMatching: false` |
+/// | Literal `contains` | `maxEditDistance: 0, acronymWeight: 0, isSubsequenceMatchingEnabled: false` |
 ///
 /// ## Gap Penalty Strategies
 ///
@@ -499,10 +499,10 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
     /// let config = EditDistanceConfig(
     ///     maxEditDistance: 0,
     ///     acronymWeight: 0,
-    ///     enableSubsequenceMatching: false
+    ///     isSubsequenceMatchingEnabled: false
     /// )
     /// ```
-    public var enableSubsequenceMatching: Bool
+    public var isSubsequenceMatchingEnabled: Bool
 
     /// The default edit distance configuration.
     public static let `default` = Self()
@@ -536,7 +536,7 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
     ///   - firstMatchBonusRange: Max position for first-match bonus. Default is `10`.
     ///   - lengthPenalty: Penalty per excess character in the candidate. Default is `0.003`.
     ///   - acronymWeight: Weight for acronym matches. Default is `1.0`.
-    ///   - enableSubsequenceMatching: Whether to fall back to gap-based subsequence matching. Default is `true`.
+    ///   - isSubsequenceMatchingEnabled: Whether to fall back to gap-based subsequence matching. Default is `true`.
     ///
     /// ## Example
     ///
@@ -580,7 +580,7 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
         firstMatchBonusRange: Int = 10,
         lengthPenalty: Double = 0.003,
         acronymWeight: Double = 1.0,
-        enableSubsequenceMatching: Bool = true
+        isSubsequenceMatchingEnabled: Bool = true
     ) {
         self.maxEditDistance = maxEditDistance
         self.longQueryMaxEditDistance = longQueryMaxEditDistance
@@ -594,7 +594,64 @@ public struct EditDistanceConfig: Sendable, Equatable, Codable {
         self.firstMatchBonusRange = firstMatchBonusRange
         self.lengthPenalty = lengthPenalty
         self.acronymWeight = acronymWeight
-        self.enableSubsequenceMatching = enableSubsequenceMatching
+        self.isSubsequenceMatchingEnabled = isSubsequenceMatchingEnabled
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case maxEditDistance
+        case longQueryMaxEditDistance
+        case longQueryThreshold
+        case prefixWeight
+        case substringWeight
+        case wordBoundaryBonus
+        case consecutiveBonus
+        case gapPenalty
+        case firstMatchBonus
+        case firstMatchBonusRange
+        case lengthPenalty
+        case acronymWeight
+        case isSubsequenceMatchingEnabled
+    }
+
+    /// Decodes a configuration, tolerating payloads serialized before a key existed.
+    ///
+    /// `isSubsequenceMatchingEnabled` was added after the initial release; older payloads
+    /// omit it and decode with the historical default (`true`) so existing serialized
+    /// configurations keep working.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.maxEditDistance = try container.decode(Int.self, forKey: .maxEditDistance)
+        self.longQueryMaxEditDistance = try container.decode(Int.self, forKey: .longQueryMaxEditDistance)
+        self.longQueryThreshold = try container.decode(Int.self, forKey: .longQueryThreshold)
+        self.prefixWeight = try container.decode(Double.self, forKey: .prefixWeight)
+        self.substringWeight = try container.decode(Double.self, forKey: .substringWeight)
+        self.wordBoundaryBonus = try container.decode(Double.self, forKey: .wordBoundaryBonus)
+        self.consecutiveBonus = try container.decode(Double.self, forKey: .consecutiveBonus)
+        self.gapPenalty = try container.decode(GapPenalty.self, forKey: .gapPenalty)
+        self.firstMatchBonus = try container.decode(Double.self, forKey: .firstMatchBonus)
+        self.firstMatchBonusRange = try container.decode(Int.self, forKey: .firstMatchBonusRange)
+        self.lengthPenalty = try container.decode(Double.self, forKey: .lengthPenalty)
+        self.acronymWeight = try container.decode(Double.self, forKey: .acronymWeight)
+        self.isSubsequenceMatchingEnabled =
+            try container.decodeIfPresent(Bool.self, forKey: .isSubsequenceMatchingEnabled) ?? true
+    }
+
+    /// Encodes the configuration into a keyed container.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(maxEditDistance, forKey: .maxEditDistance)
+        try container.encode(longQueryMaxEditDistance, forKey: .longQueryMaxEditDistance)
+        try container.encode(longQueryThreshold, forKey: .longQueryThreshold)
+        try container.encode(prefixWeight, forKey: .prefixWeight)
+        try container.encode(substringWeight, forKey: .substringWeight)
+        try container.encode(wordBoundaryBonus, forKey: .wordBoundaryBonus)
+        try container.encode(consecutiveBonus, forKey: .consecutiveBonus)
+        try container.encode(gapPenalty, forKey: .gapPenalty)
+        try container.encode(firstMatchBonus, forKey: .firstMatchBonus)
+        try container.encode(firstMatchBonusRange, forKey: .firstMatchBonusRange)
+        try container.encode(lengthPenalty, forKey: .lengthPenalty)
+        try container.encode(acronymWeight, forKey: .acronymWeight)
+        try container.encode(isSubsequenceMatchingEnabled, forKey: .isSubsequenceMatchingEnabled)
     }
 }
 

--- a/Tests/FuzzyMatchTests/ConfigTests.swift
+++ b/Tests/FuzzyMatchTests/ConfigTests.swift
@@ -587,12 +587,37 @@ import Testing
         firstMatchBonus: 0.2,
         firstMatchBonusRange: 12,
         lengthPenalty: 0.005,
-        acronymWeight: 1.2
+        acronymWeight: 1.2,
+        isSubsequenceMatchingEnabled: false
     )
 
     let data = try encoder.encode(original)
     let decoded = try decoder.decode(EditDistanceConfig.self, from: data)
     #expect(decoded == original)
+}
+
+@Test func editDistanceConfigDecodesLegacyPayloadWithoutSubsequenceKey() throws {
+    // A payload serialized before `isSubsequenceMatchingEnabled` existed must still decode,
+    // falling back to the historical default (`true`).
+    let legacyJSON = """
+    {
+        "maxEditDistance": 2,
+        "longQueryMaxEditDistance": 3,
+        "longQueryThreshold": 13,
+        "prefixWeight": 1.5,
+        "substringWeight": 1.0,
+        "wordBoundaryBonus": 0.1,
+        "consecutiveBonus": 0.05,
+        "gapPenalty": { "type": "affine", "open": 0.03, "extend": 0.005 },
+        "firstMatchBonus": 0.15,
+        "firstMatchBonusRange": 10,
+        "lengthPenalty": 0.003,
+        "acronymWeight": 1.0
+    }
+    """
+    let decoded = try JSONDecoder().decode(EditDistanceConfig.self, from: Data(legacyJSON.utf8))
+    #expect(decoded.isSubsequenceMatchingEnabled == true)
+    #expect(decoded == EditDistanceConfig())
 }
 
 @Test func smithWatermanConfigCodableRoundTrip() throws {

--- a/Tests/FuzzyMatchTests/SubsequenceMatchingTests.swift
+++ b/Tests/FuzzyMatchTests/SubsequenceMatchingTests.swift
@@ -1,0 +1,77 @@
+// ===----------------------------------------------------------------------===//
+//
+// This source file is part of the FuzzyMatch open source project
+//
+// Copyright (c) 2026 Ordo One, AB. and the FuzzyMatch project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ===----------------------------------------------------------------------===//
+
+@testable import FuzzyMatch
+import Testing
+
+// Verifies `EditDistanceConfig.enableSubsequenceMatching`. With it disabled (alongside
+// `maxEditDistance: 0` and `acronymWeight: 0`) the matcher becomes a literal, case- and
+// diacritic-insensitive `contains`: only contiguous occurrences survive.
+
+private func strictContains() -> FuzzyMatcher {
+    FuzzyMatcher(config: .init(algorithm: .editDistance(.init(
+        maxEditDistance: 0,
+        acronymWeight: 0,
+        enableSubsequenceMatching: false
+    ))))
+}
+
+@Test func defaultMatchesGapBasedSubsequence() {
+    let matcher = FuzzyMatcher()
+    let query = matcher.prepare("usd")
+    var buffer = matcher.makeBuffer()
+    // "usd" appears in order but scattered across "indUS holDing".
+    let result = matcher.score("INDUS HOLDING", against: query, buffer: &buffer)
+    #expect(result != nil)
+    #expect(result?.kind == .substring)
+}
+
+@Test func strictRejectsGapBasedSubsequence() {
+    let matcher = strictContains()
+    let query = matcher.prepare("usd")
+    var buffer = matcher.makeBuffer()
+    #expect(matcher.score("INDUS HOLDING", against: query, buffer: &buffer) == nil)
+}
+
+@Test func strictRejectsAcronym() {
+    let matcher = strictContains()
+    let query = matcher.prepare("usd")
+    var buffer = matcher.makeBuffer()
+    // "usd" is the word-initial acronym of "United States Dollar" — must not match.
+    #expect(matcher.score("United States Dollar", against: query, buffer: &buffer) == nil)
+}
+
+@Test func strictMatchesContiguousSubstring() {
+    let matcher = strictContains()
+    let query = matcher.prepare("dus")
+    var buffer = matcher.makeBuffer()
+    let result = matcher.score("INDUS HOLDING", against: query, buffer: &buffer)
+    #expect(result != nil)
+    #expect(result?.kind == .substring)
+}
+
+@Test func strictMatchesExactAndPrefix() {
+    let matcher = strictContains()
+    var buffer = matcher.makeBuffer()
+    #expect(matcher.score("USD", against: matcher.prepare("usd"), buffer: &buffer)?.kind == .exact)
+    #expect(matcher.score("USD/JPY", against: matcher.prepare("usd"), buffer: &buffer)?.kind == .prefix)
+}
+
+@Test func strictStaysDiacriticInsensitive() {
+    let matcher = strictContains()
+    var buffer = matcher.makeBuffer()
+    // Diacritic folding survives because it happens during normalization, not via the
+    // subsequence phase.
+    #expect(matcher.score("café", against: matcher.prepare("cafe"), buffer: &buffer)?.kind == .exact)
+    #expect(matcher.score("Le Café Noir", against: matcher.prepare("cafe"), buffer: &buffer)?.kind == .substring)
+}

--- a/Tests/FuzzyMatchTests/SubsequenceMatchingTests.swift
+++ b/Tests/FuzzyMatchTests/SubsequenceMatchingTests.swift
@@ -14,7 +14,7 @@
 @testable import FuzzyMatch
 import Testing
 
-// Verifies `EditDistanceConfig.enableSubsequenceMatching`. With it disabled (alongside
+// Verifies `EditDistanceConfig.isSubsequenceMatchingEnabled`. With it disabled (alongside
 // `maxEditDistance: 0` and `acronymWeight: 0`) the matcher becomes a literal, case- and
 // diacritic-insensitive `contains`: only contiguous occurrences survive.
 
@@ -22,7 +22,7 @@ private func strictContains() -> FuzzyMatcher {
     FuzzyMatcher(config: .init(algorithm: .editDistance(.init(
         maxEditDistance: 0,
         acronymWeight: 0,
-        enableSubsequenceMatching: false
+        isSubsequenceMatchingEnabled: false
     ))))
 }
 


### PR DESCRIPTION
## Summary

Adds `EditDistanceConfig.enableSubsequenceMatching` (default `true`) so the edit-distance pipeline's Phase 5 subsequence fallback can be turned off.

## Motivation

The pipeline always runs a gap-based subsequence phase that matches query characters in order with arbitrary gaps and labels the result `.substring`. There was no way to disable it, so a `FuzzyMatcher` could not be configured as a literal `contains` predicate. Concretely, `"usd"` matched:

- `"INDUS HOLDING"` — via the subsequence phase (U…S…D in order)
- `"United States Dollar"` — via the acronym phase

A downstream consumer (Ordo's client-side list filters) needs a contiguous-substring `contains`. The only workaround today is a post-hoc string comparison on every survivor, which defeats the point of using the fast matcher.

## Change

- New `enableSubsequenceMatching: Bool` on `EditDistanceConfig`, default `true` — **no behavior change** unless opted out.
- The Phase 5 `scoreSubsequence(...)` call in the `score(...)` hot path is gated on it.
- Disabled alongside `maxEditDistance: 0` and `acronymWeight: 0` (the acronym phase is already weight-gated), the matcher becomes a contiguous, case- **and diacritic-insensitive** `contains` — a non-`nil` result means the query occurs as a contiguous substring.

```swift
let contains = FuzzyMatcher(config: .init(algorithm: .editDistance(.init(
    maxEditDistance: 0,
    acronymWeight: 0,
    enableSubsequenceMatching: false
))))
```

## Tests

New `SubsequenceMatchingTests.swift`:
- default still matches `"usd"` → `"INDUS HOLDING"` as `.substring` (guards the default path)
- strict config rejects the gap-based subsequence and the acronym
- strict config still matches contiguous substring / exact / prefix
- strict config stays diacritic-insensitive (`"cafe"` → `"café"` exact, `"cafe"` → `"Le Café Noir"` substring)

Full suite green: **814 tests pass**.

## Benchmarks

`swift package --package-path Benchmarks benchmark` baseline compare (`main` → this branch), both `FuzzyMatchBenchmark` and `CorpusBenchmark`, 230 metric tables — **no regression** (compare exited 0, within thresholds):

- Deterministic counters identical (p50 Δ `0.000%`): Object allocs, Retains, Releases.
- Instruction-count deltas are sub-2% and **bidirectional** (e.g. one bench −2.1%, another +1.9%) — run-to-run/build noise on single-sample counter benches, not added work. Expected: the benches use the default config, so Phase 5 still runs; the change is a no-op on the measured path apart from one always-taken branch test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
